### PR TITLE
Change archive format to upload binaries only

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,9 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+archives:
+  - id: github
+    format: binary
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Upon further reading, we need to have the `archives` config in order to upload only the binary files instead of uploading them as `*.tar.gz` files